### PR TITLE
Added option to prompt for entropy phrase (--prompt/-p) instead of ta…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,10 +54,11 @@ dependencies = [
 
 [[package]]
 name = "brainseed"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bip39",
  "clap",
+ "rpassword",
  "sha2",
 ]
 
@@ -247,6 +248,16 @@ name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rpassword"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b763cb66df1c928432cc35053f8bd4cec3335d8559fc16010017d16b3c1680"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brainseed"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,4 +8,5 @@ edition = "2021"
 [dependencies]
 bip39 = "1.0.1"
 clap = { version = "3.2.17", features = ["derive"] }
+rpassword = "7.0.0"
 sha2 = "0.10.2"


### PR DESCRIPTION
…king at command line or input file.

This is useful for people may not want their password to be recorded in shell prompt history.